### PR TITLE
Update samples and correct cross sections

### DIFF
--- a/config/file_list.json
+++ b/config/file_list.json
@@ -205,10 +205,11 @@
         "mc16_13TeV.346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10201_p4434",
         "mc16_13TeV.346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r9364_p4434"
     ],
+
     "ZZ":[
-        "mc16_13TeV.364250.Sherpa_222_NNPDF30NNLO_llll.deriv.DAOD_STDM3.e5894_s3126_r10201_p4434",
-        "mc16_13TeV.364250.Sherpa_222_NNPDF30NNLO_llll.deriv.DAOD_STDM3.e5894_s3126_r9364_p4434",
-        "mc16_13TeV.364250.Sherpa_222_NNPDF30NNLO_llll.deriv.DAOD_STDM3.e5894_s3126_r10724_p4434",
+        "mc16_13TeV.700600.Sh_2212_llll.deriv.DAOD_STDM3.e8433_s3126_r10201_p4434",
+        "mc16_13TeV.700600.Sh_2212_llll.deriv.DAOD_STDM3.e8433_s3126_r10724_p4434",
+        "mc16_13TeV.700600.Sh_2212_llll.deriv.DAOD_STDM3.e8433_s3126_r9364_p4434",
         "mc16_13TeV.364288.Sherpa_222_NNPDF30NNLO_llll_lowMllPtComplement.deriv.DAOD_STDM3.e6096_s3126_r9364_p4434",
         "mc16_13TeV.364288.Sherpa_222_NNPDF30NNLO_llll_lowMllPtComplement.deriv.DAOD_STDM3.e6096_s3126_r10724_p4434",
         "mc16_13TeV.364288.Sherpa_222_NNPDF30NNLO_llll_lowMllPtComplement.deriv.DAOD_STDM3.e6096_s3126_r10201_p4434",
@@ -224,9 +225,9 @@
     ],
 
     "WZ":[
-        "mc16_13TeV.364253.Sherpa_222_NNPDF30NNLO_lllv.deriv.DAOD_STDM3.e5916_s3126_r10201_p4252.root",
-        "mc16_13TeV.364253.Sherpa_222_NNPDF30NNLO_lllv.deriv.DAOD_STDM3.e5916_s3126_r10724_p4252.root",
-        "mc16_13TeV.364253.Sherpa_222_NNPDF30NNLO_lllv.deriv.DAOD_STDM3.e5916_s3126_r9364_p4252.root",
+        "mc16_13TeV.700601.Sh_2212_lllv.deriv.DAOD_STDM3.e8433_s3126_r10201_p4434",
+        "mc16_13TeV.700601.Sh_2212_lllv.deriv.DAOD_STDM3.e8433_s3126_r10724_p4434",
+        "mc16_13TeV.700601.Sh_2212_lllv.deriv.DAOD_STDM3.e8433_s3126_r9364_p4434",
         "mc16_13TeV.364289.Sherpa_222_NNPDF30NNLO_lllv_lowMllPtComplement.deriv.DAOD_STDM3.e6133_s3126_r10201_p4434.root",
         "mc16_13TeV.364289.Sherpa_222_NNPDF30NNLO_lllv_lowMllPtComplement.deriv.DAOD_STDM3.e6133_s3126_r10724_p4434.root",
         "mc16_13TeV.364289.Sherpa_222_NNPDF30NNLO_lllv_lowMllPtComplement.deriv.DAOD_STDM3.e6133_s3126_r9364_p4434.root",

--- a/config/file_list.json
+++ b/config/file_list.json
@@ -190,26 +190,26 @@
         "mc16_13TeV.341454.PowhegPythia8EvtGen_CT10_AZNLO_ZH125J_MINLO_tautauWWlvqq_VpT.deriv.DAOD_STDM3.e4212_s3126_r10724_p4434"
     ],
     "Signal_WH_WZZ":[
-        "mc16_13TeV.346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10724_p4434",
-        "mc16_13TeV.346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10201_p4434",
         "mc16_13TeV.346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r9364_p4434",
-        "mc16_13TeV.346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10201_p4434",
+        "mc16_13TeV.346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10201_p4434",
+        "mc16_13TeV.346646.PowhegPythia8EvtGen_NNPDF30_AZNLO_WpH125J_Wincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10724_p4434",
         "mc16_13TeV.346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r9364_p4434",
+        "mc16_13TeV.346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10201_p4434",
         "mc16_13TeV.346647.PowhegPythia8EvtGen_NNPDF30_AZNLO_WmH125J_Wincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10724_p4434"
     ],
     "Signal_ZH_ZZZ":[
-        "mc16_13TeV.345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.deriv.DAOD_STDM3.e7735_s3126_r10201_p4434",
         "mc16_13TeV.345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.deriv.DAOD_STDM3.e7735_s3126_r9364_p4434",
+        "mc16_13TeV.345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.deriv.DAOD_STDM3.e7735_s3126_r10201_p4434",
         "mc16_13TeV.345066.PowhegPythia8EvtGen_NNPDF3_AZNLO_ggZH125_ZZ4lepZinc.deriv.DAOD_STDM3.e7735_s3126_r10724_p4434",
-        "mc16_13TeV.346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10724_p4434",
+        "mc16_13TeV.346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r9364_p4434",
         "mc16_13TeV.346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10201_p4434",
-        "mc16_13TeV.346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r9364_p4434"
+        "mc16_13TeV.346645.PowhegPythia8EvtGen_NNPDF30_AZNLO_ZH125J_Zincl_MINLO_shw.deriv.DAOD_STDM3.e7735_s3126_r10724_p4434"
     ],
 
     "ZZ":[
+        "mc16_13TeV.700600.Sh_2212_llll.deriv.DAOD_STDM3.e8433_s3126_r9364_p4434",
         "mc16_13TeV.700600.Sh_2212_llll.deriv.DAOD_STDM3.e8433_s3126_r10201_p4434",
         "mc16_13TeV.700600.Sh_2212_llll.deriv.DAOD_STDM3.e8433_s3126_r10724_p4434",
-        "mc16_13TeV.700600.Sh_2212_llll.deriv.DAOD_STDM3.e8433_s3126_r9364_p4434",
         "mc16_13TeV.364288.Sherpa_222_NNPDF30NNLO_llll_lowMllPtComplement.deriv.DAOD_STDM3.e6096_s3126_r9364_p4434",
         "mc16_13TeV.364288.Sherpa_222_NNPDF30NNLO_llll_lowMllPtComplement.deriv.DAOD_STDM3.e6096_s3126_r10724_p4434",
         "mc16_13TeV.364288.Sherpa_222_NNPDF30NNLO_llll_lowMllPtComplement.deriv.DAOD_STDM3.e6096_s3126_r10201_p4434",
@@ -225,9 +225,9 @@
     ],
 
     "WZ":[
+        "mc16_13TeV.700601.Sh_2212_lllv.deriv.DAOD_STDM3.e8433_s3126_r9364_p4434",
         "mc16_13TeV.700601.Sh_2212_lllv.deriv.DAOD_STDM3.e8433_s3126_r10201_p4434",
         "mc16_13TeV.700601.Sh_2212_lllv.deriv.DAOD_STDM3.e8433_s3126_r10724_p4434",
-        "mc16_13TeV.700601.Sh_2212_lllv.deriv.DAOD_STDM3.e8433_s3126_r9364_p4434",
         "mc16_13TeV.364289.Sherpa_222_NNPDF30NNLO_lllv_lowMllPtComplement.deriv.DAOD_STDM3.e6133_s3126_r10201_p4434.root",
         "mc16_13TeV.364289.Sherpa_222_NNPDF30NNLO_lllv_lowMllPtComplement.deriv.DAOD_STDM3.e6133_s3126_r10724_p4434.root",
         "mc16_13TeV.364289.Sherpa_222_NNPDF30NNLO_lllv_lowMllPtComplement.deriv.DAOD_STDM3.e6133_s3126_r9364_p4434.root",

--- a/src/analysis_utils.jl
+++ b/src/analysis_utils.jl
@@ -277,6 +277,18 @@ function prep_tasks(tag; shape_variation="NOMINAL", scouting=false, kw...)
         if occursin(r"346645|346646|346647", d)
             sumWeight *= 2.745e-4
         end
+        if occursin(r"341450", d)
+            sumWeight *= (11.007105/2.412326)
+        end
+        if occursin(r"341452", d)
+            sumWeight *= (11.186538/2.409899)
+        end
+        if occursin(r"341454", d)
+            sumWeight *= (11.101932/2.411167)
+        end
+        if occursin(r"345066", d)
+            sumWeight *= (57.429000/3.368E-02)
+        end
         [AnalysisTask(; path, sumWeight, isdata, shape_variation, require_VHSig, kw...) for path in PATHS]
     end
     files


### PR DESCRIPTION
Swap ZZ/WZ samples that use Sherpa 2.2.2 to Sherpa 2.2.12 [[link]](https://docs.google.com/spreadsheets/d/1Fw4aHGGV9JVZnCjkyJ85rK3wO8BR8YPzCcn2eVnpDJA/edit#gid=0)
- ZZ: 364288 -> 700600
- WZ: 364289 -> 700601

Correct the cross section of some Higgs samples [[link]](https://twiki.cern.ch/twiki/bin/view/AtlasProtected/WVZProductionRun2#v2_4)
- The internal cross section of 341450 is 11.007105 fb and should be 2.411167 fb
- The internal cross section of 341452 is 11.186538 fb and should be 2.409899 fb
- The internal cross section of 341454 is 11.101932 fb and should be 2.411167 fb
- The internal cross section of 345066 is 57.429000 fb and have 3.368e-02 fb



